### PR TITLE
metrics: add "service" in addition to "status"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM golang AS build
 
 ARG TARGETARCH
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    git \
+    libcap2-bin \
+    unzip
+
 ARG consul_version=1.22.0
 ADD https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_${TARGETARCH}.zip /usr/local/bin
 RUN cd /usr/local/bin && unzip consul_${consul_version}_linux_${TARGETARCH}.zip consul
@@ -9,7 +15,6 @@ ARG vault_version=1.21.0
 ADD https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_version}_linux_${TARGETARCH}.zip /usr/local/bin
 RUN cd /usr/local/bin && unzip vault_${vault_version}_linux_${TARGETARCH}.zip vault
 
-RUN apt-get update && apt-get install -y git ca-certificates libcap2-bin
 WORKDIR /src
 COPY . .
 RUN go mod tidy

--- a/main.go
+++ b/main.go
@@ -344,7 +344,7 @@ func startServers(cfg *config.Config, stats metrics.Provider) {
 			Requests:        stats.NewHistogram("requests"),
 			Noroute:         notFound,
 			WSConn:          stats.NewGauge("ws.conn"),
-			StatusTimer:     stats.NewHistogram("http.status", "code"),
+			StatusTimer:     stats.NewHistogram("http.status", "code", "service"),
 			RedirectCounter: stats.NewCounter("http.redirect.count", "code"),
 		}
 	}

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -235,7 +235,8 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if p.Stats.StatusTimer != nil {
-		p.Stats.StatusTimer.With("code", strconv.Itoa(rw.code)).Observe(dur.Seconds())
+		p.Stats.StatusTimer.With("code", strconv.Itoa(rw.code), "service", t.Service).
+			Observe(dur.Seconds())
 	}
 
 	// write access log


### PR DESCRIPTION
This PR will be proposed also upstream, although given the increase in label cardinality I don't know if it will be accepted...

- metrics: add label "service" to bucket http_status
  - Before, this bucket was the only metrics variable reporting on the status code,
but it was global, for all the services proxied by fabio.
  - This obviously increases the metrics cardinality, but I _think_ it is OK.

- build: make Dockerfile actually build. Unclear how it worked before.

Testing: tested in my dev-$USER.